### PR TITLE
Fix: data pipeline overhaul — scheduler, donors, lobbying, stock trades

### DIFF
--- a/backend/app/routers/refresh.py
+++ b/backend/app/routers/refresh.py
@@ -178,8 +178,13 @@ async def refresh_entity(slug: str, db: AsyncSession = Depends(get_db)):
                 new_donors = 0
                 # Fetch both: top donors by amount + ALL PAC/committee donors
                 fetch_configs = [
-                    {"cycle": 2024, "per_page": 50, "params": {}},
-                    {"cycle": 2022, "per_page": 50, "params": {}},
+                    # Individual donors — 100 per cycle across 4 cycles
+                    {"cycle": 2026, "per_page": 100, "params": {}},
+                    {"cycle": 2024, "per_page": 100, "params": {}},
+                    {"cycle": 2022, "per_page": 100, "params": {}},
+                    {"cycle": 2020, "per_page": 100, "params": {}},
+                    # PAC/committee donors — 100 per cycle across 4 cycles
+                    {"cycle": 2026, "per_page": 100, "params": {"contributor_type": "committee"}},
                     {"cycle": 2024, "per_page": 100, "params": {"contributor_type": "committee"}},
                     {"cycle": 2022, "per_page": 100, "params": {"contributor_type": "committee"}},
                     {"cycle": 2020, "per_page": 100, "params": {"contributor_type": "committee"}},
@@ -352,8 +357,172 @@ async def refresh_entity(slug: str, db: AsyncSession = Depends(get_db)):
                 except Exception:
                     pass
 
+        # 6b. Fetch stock trades for House members
+        chamber = (meta.get("chamber") or "").lower()
+        if "house" in chamber:
+            try:
+                from app.services.ingestion.house_trades import (
+                    fetch_house_ptr_index, parse_ptr_pdf, _get_or_create_stock, _parse_date,
+                    HOUSE_PTR_PDF_URL,
+                )
+                # Extract name parts for matching
+                official_name = entity.name.lower().replace(",", " ").split()
+                official_name = [p.strip() for p in official_name if len(p.strip()) > 1]
+                trades_created = 0
+                for year in [2025, 2024]:
+                    try:
+                        filings = await fetch_house_ptr_index(year)
+                        matched = [
+                            f for f in filings
+                            if f["last"].lower() in " ".join(official_name)
+                            or any(p in f["last"].lower() for p in official_name if len(p) > 3)
+                        ]
+                        for filing in matched[:10]:  # Cap at 10 filings
+                            await asyncio.sleep(1)
+                            try:
+                                pdf_url = HOUSE_PTR_PDF_URL.format(year=year, doc_id=filing["doc_id"])
+                                async with httpx.AsyncClient(timeout=30.0) as pdf_client:
+                                    pdf_resp = await pdf_client.get(pdf_url)
+                                    pdf_resp.raise_for_status()
+                                trades = parse_ptr_pdf(pdf_resp.content)
+                                for trade in trades:
+                                    stock_entity = await _get_or_create_stock(db, trade["ticker"], trade["asset"])
+                                    trade_date = _parse_date(trade["trade_date"])
+                                    source_url = pdf_url
+                                    # Duplicate check
+                                    dup = (await db.execute(
+                                        select(Relationship).where(
+                                            Relationship.from_entity_id == entity.id,
+                                            Relationship.to_entity_id == stock_entity.id,
+                                            Relationship.relationship_type == "stock_trade",
+                                            Relationship.source_url == source_url,
+                                            Relationship.date_start == trade_date,
+                                        )
+                                    )).scalar_one_or_none()
+                                    if not dup:
+                                        db.add(Relationship(
+                                            from_entity_id=entity.id,
+                                            to_entity_id=stock_entity.id,
+                                            relationship_type="stock_trade",
+                                            amount_label=trade["amount_range"],
+                                            date_start=trade_date,
+                                            source_url=source_url,
+                                            source_label="House Clerk PTR",
+                                            metadata_={
+                                                "ticker": trade["ticker"],
+                                                "transaction_type": trade["transaction_type"],
+                                                "amount_range": trade["amount_range"],
+                                                "owner": trade.get("owner", ""),
+                                                "doc_id": filing["doc_id"],
+                                                "source": "House Clerk PTR",
+                                            },
+                                        ))
+                                        trades_created += 1
+                            except Exception:
+                                pass
+                    except Exception:
+                        pass
+                if trades_created:
+                    actions.append(f"fetched {trades_created} stock trades (House PTR)")
+            except Exception as e:
+                actions.append(f"stock trade fetch failed: {e}")
+
         # 7. Commit all data changes before computing verdicts
         await db.commit()
+
+        # 7b. Fetch lobbying data for bills this official sponsors
+        try:
+            bills_q = await db.execute(
+                select(Entity).join(
+                    Relationship, Relationship.to_entity_id == Entity.id
+                ).where(
+                    Relationship.from_entity_id == entity.id,
+                    Relationship.relationship_type.in_(["sponsored", "cosponsored"]),
+                    Entity.entity_type == "bill",
+                )
+            )
+            official_bills = bills_q.scalars().all()
+            if official_bills:
+                bill_lookup = {b.slug: b.id for b in official_bills}
+                lda_new = 0
+                async with httpx.AsyncClient(timeout=30.0) as lda_http:
+                    for year in [2025, 2024]:
+                        await asyncio.sleep(DELAY)
+                        try:
+                            resp = await lda_http.get(
+                                "https://lda.senate.gov/api/v1/filings/",
+                                params={"filing_year": year, "per_page": 50},
+                                headers={"Accept": "application/json"},
+                                timeout=30.0,
+                            )
+                            if resp.status_code == 200:
+                                filings = resp.json().get("results", [])
+                                for filing in filings:
+                                    client_info = filing.get("client") or {}
+                                    client_name = _ascii_safe((client_info.get("name") or "").strip())
+                                    if not client_name:
+                                        continue
+                                    filing_uuid = filing.get("filing_uuid", "")
+                                    activities = filing.get("lobbying_activities") or []
+                                    for activity in activities:
+                                        desc = activity.get("description", "")
+                                        if not desc:
+                                            continue
+                                        # Check if this filing references any of our bills
+                                        import re as _re2
+                                        bill_nums = _re2.findall(
+                                            r'(?:H\.?\s*R\.?|S\.?|H\.?\s*Res\.?|S\.?\s*Res\.?)\s*(\d{1,5})',
+                                            desc, _re2.IGNORECASE
+                                        )
+                                        for num in bill_nums:
+                                            for congress in [119, 118]:
+                                                for prefix in [f"s-{num}-{congress}", f"{num}-{congress}"]:
+                                                    bill_id = bill_lookup.get(prefix)
+                                                    if bill_id:
+                                                        client_slug = _slugify(client_name)
+                                                        if not client_slug:
+                                                            continue
+                                                        # Find or create client entity
+                                                        client_ent = (await db.execute(
+                                                            select(Entity).where(Entity.slug == client_slug)
+                                                        )).scalar_one_or_none()
+                                                        if not client_ent:
+                                                            client_ent = Entity(
+                                                                slug=client_slug[:195],
+                                                                entity_type="organization",
+                                                                name=client_name[:490],
+                                                                metadata_={"source": "Senate LDA"},
+                                                            )
+                                                            db.add(client_ent)
+                                                            await db.flush()
+                                                        # Check for existing relationship
+                                                        existing_lob = (await db.execute(
+                                                            select(Relationship).where(
+                                                                Relationship.from_entity_id == client_ent.id,
+                                                                Relationship.to_entity_id == bill_id,
+                                                                Relationship.relationship_type == "lobbied_on",
+                                                            ).limit(1)
+                                                        )).scalar_one_or_none()
+                                                        if not existing_lob:
+                                                            db.add(Relationship(
+                                                                from_entity_id=client_ent.id,
+                                                                to_entity_id=bill_id,
+                                                                relationship_type="lobbied_on",
+                                                                source_label="Senate LDA",
+                                                                source_url=f"https://lda.senate.gov/filings/{filing_uuid}/",
+                                                                metadata_=_ascii_safe({
+                                                                    "description": desc[:500],
+                                                                    "filing_year": year,
+                                                                }),
+                                                            ))
+                                                            lda_new += 1
+                        except (httpx.ConnectError, OSError):
+                            pass  # Senate LDA may be unreachable
+                if lda_new:
+                    await db.commit()
+                    actions.append(f"fetched {lda_new} lobbying relationships for bills")
+        except Exception as e:
+            actions.append(f"lobbying fetch failed: {e}")
 
         # 8. Compute money trail verdicts (connect the dots) — with retry
         verdict_ok = False

--- a/backend/app/services/ingestion/fec_client.py
+++ b/backend/app/services/ingestion/fec_client.py
@@ -3,7 +3,7 @@ import json
 import httpx
 
 BASE_URL = "https://api.open.fec.gov/v1"
-MAX_PAGES = 3
+MAX_PAGES = 5
 TIMEOUT = 30.0
 
 

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -70,26 +70,30 @@ async def _record_ingestion_job(
     session, job_id: str, status: str, records_fetched: int = 0,
     records_created: int = 0, error_message: str = "",
 ):
-    """Record an ingestion job run. IngestionJob model is provided by Agent A."""
+    """Record an ingestion job run."""
     try:
         from app.models import IngestionJob
+        from datetime import datetime, timezone
+
         job = IngestionJob(
-            job_id=job_id,
+            job_type=job_id,
             status=status,
-            records_fetched=records_fetched,
-            records_created=records_created,
-            error_message=error_message,
+            started_at=datetime.now(timezone.utc),
+            completed_at=datetime.now(timezone.utc) if status in ("completed", "failed", "skipped") else None,
+            metadata_={
+                "records_fetched": records_fetched,
+                "records_created": records_created,
+            },
+            errors=[{"message": error_message}] if error_message else [],
         )
         session.add(job)
         await session.commit()
-    except ImportError:
-        # IngestionJob model not yet available — log and skip
-        logger.debug(
-            "IngestionJob model not available; skipping ingestion record for %s",
-            job_id,
-        )
     except Exception as exc:
         logger.warning("Failed to record ingestion job %s: %s", job_id, exc)
+        try:
+            await session.rollback()
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -111,39 +115,45 @@ async def _fetch_new_trades():
         records_created = 0
 
         try:
-            from app.services.ingestion.efd_client import EFDClient
-
-            efd = EFDClient()
-
-            # Fetch PTRs via the eFD search
             import httpx
 
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    "https://efts.senate.gov/LATEST/search-results",
-                    params={
-                        "type": "ptr",
-                        "dateRange": "custom",
-                        "fromDate": from_date.strftime("%m/%d/%Y"),
-                        "toDate": to_date.strftime("%m/%d/%Y"),
-                    },
-                )
-                if response.status_code == 200:
-                    try:
-                        data = response.json()
-                    except Exception:
-                        data = []
+            # Fetch PTRs via Senate eFD search with retry and DNS error handling
+            results = []
+            for attempt in range(3):
+                try:
+                    async with httpx.AsyncClient(timeout=30.0) as client:
+                        response = await client.get(
+                            "https://efts.senate.gov/LATEST/search-results",
+                            params={
+                                "type": "ptr",
+                                "dateRange": "custom",
+                                "fromDate": from_date.strftime("%m/%d/%Y"),
+                                "toDate": to_date.strftime("%m/%d/%Y"),
+                            },
+                        )
+                        if response.status_code == 200:
+                            try:
+                                data = response.json()
+                            except Exception:
+                                data = []
+                            results = data if isinstance(data, list) else data.get("results", [])
+                        else:
+                            logger.warning(
+                                "[Scheduler] eFD returned status %s", response.status_code
+                            )
+                    break  # Success, exit retry loop
+                except (httpx.ConnectError, OSError) as dns_err:
+                    if attempt < 2:
+                        import asyncio
+                        logger.info("[Scheduler] eFD connection failed (attempt %d), retrying: %s", attempt + 1, dns_err)
+                        await asyncio.sleep(5)
+                    else:
+                        logger.warning("[Scheduler] eFD unreachable after 3 attempts: %s", dns_err)
 
-                    results = data if isinstance(data, list) else data.get("results", [])
-                    records_fetched = len(results)
-
-                    for record in results:
-                        await _process_ptr_record(session, record)
-                        records_created += 1
-                else:
-                    logger.warning(
-                        "[Scheduler] eFD returned status %s", response.status_code
-                    )
+            records_fetched = len(results)
+            for record in results:
+                await _process_ptr_record(session, record)
+                records_created += 1
 
             # Clear stale is_new flags
             from app.services.trade_alerts import clear_stale_new_flags
@@ -199,7 +209,7 @@ async def _process_ptr_record(session, record: dict):
         result = await session.execute(
             select(Entity).where(
                 Entity.name.ilike(f"%{senator_name}%"),
-                Entity.entity_type == "official",
+                Entity.entity_type == "person",
             )
         )
         official = result.scalar_one_or_none()
@@ -296,7 +306,7 @@ async def _fetch_new_votes():
 
             # Get all officials with bioguide_id
             stmt = select(Entity).where(
-                Entity.entity_type == "official",
+                Entity.entity_type == "person",
                 Entity.metadata_["bioguide_id"].astext.isnot(None),
             )
             result = await session.execute(stmt)
@@ -373,7 +383,7 @@ async def _fetch_new_bills():
 
             # Fetch bills for all tracked officials
             stmt = select(Entity).where(
-                Entity.entity_type == "official",
+                Entity.entity_type == "person",
                 Entity.metadata_["bioguide_id"].astext.isnot(None),
             )
             result = await session.execute(stmt)
@@ -444,7 +454,7 @@ async def _fetch_fec_updates():
 
             # Get officials with FEC candidate IDs
             stmt = select(Entity).where(
-                Entity.entity_type == "official",
+                Entity.entity_type == "person",
                 Entity.metadata_["fec_candidate_id"].astext.isnot(None),
             )
             result = await session.execute(stmt)
@@ -501,7 +511,7 @@ async def _refresh_conflicts():
             from app.services.conflict_engine import detect_conflicts
             from sqlalchemy import select
 
-            stmt = select(Entity).where(Entity.entity_type == "official")
+            stmt = select(Entity).where(Entity.entity_type == "person")
             result = await session.execute(stmt)
             officials = result.scalars().all()
 


### PR DESCRIPTION
## Summary
- **Issue #4 — Scheduler:** Fixed 3 bugs: IngestionJob model field mismatch (`job_id` -> `job_type`), DNS retry for Senate eFD, entity_type `"official"` -> `"person"` (all scheduled jobs found 0 politicians)
- **Issue #5 — Stock trades:** Refresh now fetches House Clerk PTR filings for House members, parses PDFs, creates `stock_trade` relationships
- **Issue #6 — Lobbying data:** Refresh now fetches Senate LDA filings matching politician's sponsored bills, creates `lobbied_on` relationships
- **Issue #7 — Donor coverage:** Doubled individual donor fetch (50→100 per cycle), added 2026+2020 cycles, increased FEC pagination (3→5 pages)

## Test Results
**Gottheimer (House member) full investigation:**
- 259 new donors (was ~100)
- 404 stock trades from House PTR (was 0)
- 15 money trails, verdict: OWNED (44 dots)
- 4/5 influence signals found
- AI briefing generated (3,077 chars)

**Scheduler:** No more `'job_id' is an invalid keyword argument` errors, votes job now finds real politicians

## Test plan
- [x] Tested full investigation on House member (Gottheimer) — stock trades + donors working
- [x] Tested scheduler manual trigger — no model errors, finds officials correctly
- [x] Verified influence signals still compute (fresh session fix from PR #3)
- [x] Syntax-checked all modified files

Closes #4, Closes #5, Closes #6, Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)