### PR TITLE
fix: correct eFD response parsing + fault-tolerant trade ingestion

### DIFF
--- a/backend/app/services/ingestion/efd_client.py
+++ b/backend/app/services/ingestion/efd_client.py
@@ -212,14 +212,23 @@ class EFDClient:
         records = []
         for row in data.get("data", []):
             if isinstance(row, list) and len(row) >= 5:
-                name_parts = re.sub(r"<[^>]+>", "", row[0]).strip().split(", ")
+                # eFD DataTables column layout (as of ~May 2026):
+                #   [0] first name          e.g. "Sheldon"
+                #   [1] last name           e.g. "Whitehouse"
+                #   [2] "Last, First (Office)" e.g. "Whitehouse, Sheldon (Senator)"
+                #   [3] <a href="/search/view/ptr/{uuid}/">Periodic Transaction
+                #        Report for {date}</a>
+                #   [4] date received       e.g. "06/02/2026"
+                first_name = _strip_tags(row[0])
+                last_name = _strip_tags(row[1])
+                office_match = re.search(r"\(([^)]+)\)", _strip_tags(row[2]))
                 records.append({
-                    "last_name": name_parts[0] if name_parts else "",
-                    "first_name": name_parts[1] if len(name_parts) > 1 else "",
-                    "office": re.sub(r"<[^>]+>", "", row[1]).strip(),
-                    "report_type": re.sub(r"<[^>]+>", "", row[2]).strip(),
-                    "date_received": re.sub(r"<[^>]+>", "", row[3]).strip(),
-                    "report_url": _extract_href(row[4]),
+                    "first_name": first_name,
+                    "last_name": last_name,
+                    "office": office_match.group(1) if office_match else "",
+                    "report_type": _strip_tags(row[3]),
+                    "date_received": _strip_tags(row[4]),
+                    "report_url": _extract_href(row[3]),
                 })
             elif isinstance(row, dict):
                 records.append(row)
@@ -333,6 +342,11 @@ class EFDClient:
         logger.info("[EFDClient] Data written to %s", output_path)
 
         return result
+
+
+def _strip_tags(html: str) -> str:
+    """Strip HTML tags and surrounding whitespace from a cell value."""
+    return re.sub(r"<[^>]+>", "", str(html)).strip()
 
 
 def _extract_href(html: str) -> str:

--- a/backend/app/services/scheduler.py
+++ b/backend/app/services/scheduler.py
@@ -153,7 +153,18 @@ async def _fetch_new_trades():
             records_fetched = len(results)
             alerts_created = 0
             for record in results:
-                rel, pattern = await _process_ptr_record(session, record)
+                try:
+                    rel, pattern = await _process_ptr_record(session, record)
+                except Exception as exc:
+                    # One malformed record must not abort the whole batch.
+                    logger.warning(
+                        "[Scheduler] %s: skipping record (%s %s): %s",
+                        job_id,
+                        record.get("first_name", ""),
+                        record.get("last_name", ""),
+                        exc,
+                    )
+                    continue
                 if rel:
                     records_created += 1
                     # Create trade alert
@@ -260,7 +271,10 @@ async def _process_ptr_record(session, record: dict):
                 Entity.entity_type == "person",
             )
         )
-        official = result.scalar_one_or_none()
+        # A partial name match can legitimately return several people
+        # (e.g. two senators sharing a surname); take the first rather
+        # than crashing the whole batch on MultipleResultsFound.
+        official = result.scalars().first()
 
     if not official:
         logger.debug("No entity found for senator: %s", senator_name)


### PR DESCRIPTION
## Context

Follow-up to #36 (which fixed the HTTP 503 from bare date filters). Backfilling the recovered window surfaced **two more latent bugs** — both hidden for 23 days because the 503 meant we never parsed a live eFD response.

## Bug 1 — response columns realigned

The Senate eFD reordered its DataTables columns. The parser still expected the old layout, so **every field was wrong**:
- first/last names swapped
- `report_url` always empty (`_extract_href` was run on the date cell)
- `date_received` read from the report-link cell

Realigned to the current layout and added a `_strip_tags` helper:

| col | content |
|---|---|
| `[0]` | first name |
| `[1]` | last name |
| `[2]` | `Last, First (Office)` |
| `[3]` | `<a href="…/ptr/{uuid}/">…</a>` |
| `[4]` | date received |

## Bug 2 — one bad record killed the whole batch

A partial name lookup matching multiple people raised `MultipleResultsFound`, aborting the entire run on the first such record. Now uses `.scalars().first()`, and per-record processing is wrapped in try/except (skip + log, don't abort).

## Testing

- Unit assertions on `_strip_tags`, `_extract_href`, `_normalize_efd_date`
- **Live** parse of 9 records: correct names/offices/filed-dates, all source URLs present
- **Live** `fetch_new_trades` backfill: 28 fetched, 3 new trades created, no crash; trades attach to the correct senator with working eFD links

## Known limitation (follow-up, not a regression)

The search-list response carries filing-level metadata only — ticker / buy-sell / amount live inside each PTR's linked document. Parsing those documents to enrich trades is a separate enhancement, tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)